### PR TITLE
[R4R]add new service status API

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -8,6 +8,8 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
+const goSDKSource = "2"
+
 type Client struct {
 	rpc.Client
 }
@@ -36,6 +38,7 @@ func (ec *Client) Close() {
 
 func (ec *Client) SendBundle(ctx context.Context, bundle *SendBundleArgs) (common.Hash, error) {
 	var hash common.Hash
+	ec.SetHeader("Request-Source", goSDKSource)
 	err := ec.CallContext(context.Background(), &hash, "eth_sendBundle", bundle)
 	return hash, err
 }
@@ -52,4 +55,11 @@ func (ec *Client) GetBundleByHash(ctx context.Context, hash common.Hash) (*Bundl
 
 	err := ec.CallContext(context.Background(), &bundle, "txpool_getBundleByHash", hash)
 	return &bundle, err
+}
+
+func (ec *Client) GetStatus(ctx context.Context) (*Status, error) {
+	var status Status
+
+	err := ec.CallContext(context.Background(), &status, "eth_validatorStatus")
+	return &status, err
 }

--- a/client/types.go
+++ b/client/types.go
@@ -25,3 +25,8 @@ type Bundle struct {
 	Hash              common.Hash
 	Price             *big.Int
 }
+
+type Status struct {
+	Status     int64            `json:"status"`
+	Validators map[string]int64 `json:"validators"`
+}

--- a/example/example.go
+++ b/example/example.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/ethereum/go-ethereum/common"
 	"log"
 	"math/big"
 	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/params"
@@ -36,6 +36,16 @@ func getBundlePriceDemo() {
 	fmt.Printf("get bundle price price %s\n", price.String())
 }
 
+func getServiceStatus() {
+	directClient, _ := client.Dial(directRouteEndPoint)
+	s, err := directClient.GetStatus(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	bz, _ := json.Marshal(s)
+	fmt.Println(string(bz))
+}
+
 /**
 In this case, we try to use two accounts to send BNB to each other,
 the two transaction should be all success or all failed.
@@ -43,7 +53,10 @@ the two transaction should be all success or all failed.
 func sendBNBByBundleDemo() {
 	directClient, _ := client.Dial(directRouteEndPoint)
 	rpcClient, _ := ethclient.Dial(rpcEndPoint)
-	price, _ := directClient.BundlePrice(context.Background())
+	price, err := directClient.BundlePrice(context.Background())
+	if err != nil {
+		log.Fatalf("failed to get bundle price%v", err)
+	}
 
 	n1, _ := rpcClient.PendingNonceAt(context.Background(), account1.Addr)
 	n2, _ := rpcClient.PendingNonceAt(context.Background(), account2.Addr)
@@ -79,7 +92,7 @@ func sendBNBByBundleDemo() {
 	fmt.Printf("The bundle is %s\n", string(bz))
 
 	found := false
-	for i := 0; i < 21; i++ {
+	for i := 0; i < 42; i++ {
 		r1, err1 := rpcClient.TransactionReceipt(context.Background(), hash1)
 		r2, err2 := rpcClient.TransactionReceipt(context.Background(), hash2)
 		if r1 != nil && err1 == nil && r2 != nil && err2 == nil {
@@ -145,7 +158,7 @@ func sendBUSDByBundleDemo() {
 	fmt.Printf("The bundle is %s\n", string(bz))
 
 	found := false
-	for i := 0; i < 30; i++ {
+	for i := 0; i < 60; i++ {
 		r1, err1 := rpcClient.TransactionReceipt(context.Background(), hash1)
 		r2, err2 := rpcClient.TransactionReceipt(context.Background(), hash2)
 		if r1 != nil && err1 == nil && r2 != nil && err2 == nil {


### PR DESCRIPTION
## Description
The SDK implements a new function to query the status of the direct route.

## Example
curl -s -X POST  -data '{"jsonrpc": "2.0", "method": "eth_validatorStatus", "id": 1}' -H "Content-Type: application/json" 
{"jsonrpc":"2.0","id":1,"result":{"status":0,"validators":{"nodeReal":0}}}

## Impaction
Compatible with previous version